### PR TITLE
Migrate from Cages (Beta) to Enclaves (Stable)

### DIFF
--- a/.github/workflows/deploy-dev-cage.yml
+++ b/.github/workflows/deploy-dev-cage.yml
@@ -1,7 +1,7 @@
 name: Deploy Dev Cage
 
 env:
-  TOML_FILE_NAME: 'cage.dev.toml'
+  TOML_FILE_NAME: 'enclave.dev.toml'
   STAGE: dev
 
 on:
@@ -25,10 +25,10 @@ jobs:
           EV_KEY: ${{ secrets.DEV_EVERVAULT_KEY }}
 
         run: |
-          sh <(curl https://cage-build-assets.evervault.com/cli/install -sL)
+          curl https://enclave-build-assets.evervault.com/cli/v1/install -sL | sh
           echo "$EV_CERT" > cert.pem
           echo "$EV_KEY" > key.pem
-          ev-cage deploy -c $TOML_FILE_NAME
+          ev-enclave deploy -c $TOML_FILE_NAME
 
       - name: Save PCR Attestations to Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-prod-cage.yml
+++ b/.github/workflows/deploy-prod-cage.yml
@@ -1,7 +1,7 @@
 name: Deploy Prod Cage
 
 env:
-  TOML_FILE_NAME: 'cage.prod.toml'
+  TOML_FILE_NAME: 'enclave.prod.toml'
   STAGE: 'prod'
 
 on:
@@ -25,10 +25,10 @@ jobs:
           EV_KEY: ${{ secrets.PROD_EVERVAULT_KEY }}
 
         run: |
-          sh <(curl https://cage-build-assets.evervault.com/cli/install -sL)
+          curl https://enclave-build-assets.evervault.com/cli/v1/install -sL | sh
           echo "$EV_CERT" > cert.pem
           echo "$EV_KEY" > key.pem
-          ev-cage deploy -c $TOML_FILE_NAME
+          ev-enclave deploy -c $TOML_FILE_NAME
 
       - name: Save PCR Attestations
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-staging-cage.yml
+++ b/.github/workflows/deploy-staging-cage.yml
@@ -1,7 +1,7 @@
 name: Deploy Staging Cage
 
 env:
-  TOML_FILE_NAME: 'cage.staging.toml'
+  TOML_FILE_NAME: 'enclave.staging.toml'
   STAGE: staging
 
 on:
@@ -25,10 +25,10 @@ jobs:
           EV_KEY: ${{ secrets.STAGING_EVERVAULT_KEY }}
 
         run: |
-          sh <(curl https://cage-build-assets.evervault.com/cli/install -sL)
+          curl https://enclave-build-assets.evervault.com/cli/v1/install -sL | sh
           echo "$EV_CERT" > cert.pem
           echo "$EV_KEY" > key.pem
-          ev-cage deploy -c $TOML_FILE_NAME
+          ev-enclave deploy -c $TOML_FILE_NAME
 
       - name: Save PCR Attestations
         uses: actions/upload-artifact@v3

--- a/enclave.dev.toml
+++ b/enclave.dev.toml
@@ -1,0 +1,30 @@
+version = 1
+name = "nitro-secure-service-dev"
+uuid = "cage_49cd44b168a0"
+app_uuid = "app_b81dd8dc1c0d"
+team_uuid = "team_e59a7c8b0849"
+debug = false
+dockerfile = "./Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = []
+
+[egress]
+enabled = false
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+
+[attestation]
+HashAlgorithm = "Sha384 { ... }"
+PCR0 = "57a851cd23e1052637303bbd0a535eea94acf0089d9cf99ed4c5667c57508d63df5178dc88a55f51cc9ad5b758231e8d"
+PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
+PCR2 = "9a513cad32c0ca4eddf5c3710d149f6d12d08d74f9b263282395fd212c6b23cd02883b6d381e722abffae02d067d1837"
+PCR8 = "d00f3481190e86c7a0bf2fcfbad9220bf7f7667c392cb0269d70877a286b7374cb4b26bfc0d11f34374c8bfd09e374e7"
+
+[runtime]
+data_plane_version = "0.0.37"
+installer_version = "b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c"

--- a/enclave.prod.toml
+++ b/enclave.prod.toml
@@ -1,0 +1,30 @@
+version = 1
+name = "nitro-secure-service-prod"
+uuid = "cage_828970c9b3b2"
+app_uuid = "app_d7c0fe35a2d6"
+team_uuid = "team_e59a7c8b0849"
+debug = false
+dockerfile = "./Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = []
+
+[egress]
+enabled = false
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+
+[attestation]
+HashAlgorithm = "Sha384 { ... }"
+PCR0 = "b7b8ee3852bcd66226456112c2b291a1991ce62b67ea6c026bd678338637ec9c09ca6be81a00bef0399d5279495e5146"
+PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
+PCR2 = "e3f08c1f85941e527330588a688549a0797d063c0cf5ab98987d3c54c5fb04a31e955192826b673f37cdfbc556da48aa"
+PCR8 = "751cb1301ced11bbb7c0180ec0da8083912aefb8384cd79c3844e055d119f8a3f303207b042dec75b743aac0485eeb41"
+
+[runtime]
+data_plane_version = "0.0.41"
+installer_version = "b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c"

--- a/enclave.staging.toml
+++ b/enclave.staging.toml
@@ -1,0 +1,19 @@
+version = 1
+name = "nitro-secure-service-staging"
+uuid = "cage_429c6f3ba413"
+app_uuid = "app_a6f793e80534"
+team_uuid = "team_e59a7c8b0849"
+debug = false
+dockerfile = "./Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = []
+
+[egress]
+enabled = false
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"


### PR DESCRIPTION
Per ZEL-940, migrate from the Evervault Cages Beta to the stable "Enclaves" product. This PR includes the updated Enclave TOML file format (generated with `ev-enclave migrate`, and updated github actions workflows to deploy the cages to the new enclave runtimes.

Closes the following (once merged through to production): 
- ZEL-943
- ZEL-944
- ZEL-946

**This PR is not expecting to be breaking, but the Encrypted Key Management Service on the DEV environment should be tested once this PR is merged & deployment is completed** to ensure compatibility. 

Per ZEL-947, we should update the Evervault SDK in dependent services (e.g. the EKMS) and use the new enclave methods (instead of the deprecated cage methods) _after_ this PR is merged for each stage of the Nitro service:
* Merge nitro service updates `dev` -> update EKMS on dev
* Merge nitro service updates to `staging` -> update EKMS on staging
* Merge nitro service updates to `master` -> update EKMS on prod